### PR TITLE
Depends

### DIFF
--- a/option/types_.py
+++ b/option/types_.py
@@ -22,7 +22,14 @@
 
 # pylint: skip-file
 
-from typing import Protocol, TypeVar
+import sys
+from typing import TypeVar
+
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol
+
 
 T = TypeVar('T')
 U = TypeVar('U')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["poetry_core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
 [tool.poetry]
 name = "option"
 version = "1.0.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ include = ['option/py.typed', 'option/**/*.py', 'LICENSE']
 
 [tool.poetry.dependencies]
 python = ">=3.6"
+typing-extensions = { version = ">=4.0", python = "<3.8" }
 
 [tool.poetry.dev-dependencies]
 pytest = "*"


### PR DESCRIPTION
- Add build system requirements (PEP 518) so build is possible without poetry (with pip or python -m build)
- Depend on typing-extensions for python <3.8
